### PR TITLE
Windows 0.51

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ time_rs = ["time"]
 serde = [ "dep:serde", "time?/serde", "time?/serde-human-readable" ]
 
 [dependencies]
-windows = { version = "0.48", features = [
+windows = { version = "0.51", features = [
     "Win32_Foundation",
     "Win32_Security_Authorization",
     "Win32_System_Diagnostics_Etw",

--- a/src/native/etw_types.rs
+++ b/src/native/etw_types.rs
@@ -6,6 +6,8 @@
 //!
 //! In most cases a user of the crate won't have to deal with this and can directly obtain the data
 //! needed by using the functions exposed by the modules at the crate level
+#![allow(clippy::bad_bit_mask)]
+
 use crate::provider::event_filter::EventFilterDescriptor;
 use crate::provider::TraceFlags;
 use crate::trace::{TraceProperties, RealTimeTraceTrait};

--- a/src/native/time.rs
+++ b/src/native/time.rs
@@ -1,4 +1,4 @@
-///! Implements wrappers for various Windows time structures.
+//! Implements wrappers for various Windows time structures.
 use windows::Win32::{
     Foundation::{FILETIME, SYSTEMTIME},
     System::Time::SystemTimeToFileTime,

--- a/src/native/version_helper.rs
+++ b/src/native/version_helper.rs
@@ -62,12 +62,10 @@ fn verify_system_version(major: u8, minor: u8, sp_major: u16) -> VersionHelperRe
     let error = unsafe{ GetLastError() };
 
     // See https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-verifyversioninfoa#return-value
-    match (res.as_bool(), error) {
+    match (res.is_ok(), error) {
         (true, _) => Ok(true),
-        (false, ERROR_OLD_WIN_VERSION) => Ok(false),
-        (false, _err) => Err(
-            VersionHelperError::IoError(std::io::Error::last_os_error())
-        ),
+        (false, Err(err)) if err.code() == ERROR_OLD_WIN_VERSION.to_hresult() => Ok(false),
+        (false, _err) => Err(VersionHelperError::IoError(std::io::Error::last_os_error())),
     }
 }
 

--- a/src/provider/event_filter.rs
+++ b/src/provider/event_filter.rs
@@ -124,7 +124,7 @@ impl EventFilterDescriptor {
             return Err("Too many PIDs are filtered".into());
         }
 
-        let data_size = pids.len() * std::mem::size_of::<u16>(); // PIDs are WORD, i.e. 16bits
+        let data_size = std::mem::size_of_val(pids); // PIDs are WORD, i.e. 16bits
 
         let mut s = Self::try_new::<u16>(data_size)?;
         s.ty = EVENT_FILTER_TYPE_PID;


### PR DESCRIPTION
- Add allow for lint due to Windows values
- Update to `windows-rs` 0.51
- nits: unused doc comment and manual size computation
